### PR TITLE
feat(cli): scenario summary printer

### DIFF
--- a/src/bench_core/__init__.py
+++ b/src/bench_core/__init__.py
@@ -1,0 +1,5 @@
+from . import cli  # re-export for `from bench_core import cli`
+
+__all__ = [
+    "cli",
+]

--- a/src/bench_core/cli.py
+++ b/src/bench_core/cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Iterable, List
+
+from . import loader
+
+
+def _format_summary(cfg) -> str:
+    lines: List[str] = []
+    lines.append(f"schema_version: {cfg.schema_version}")
+    lines.append(f"scenario_name: {cfg.scenario_name}")
+    lines.append(f"workload.streaming: {cfg.workload.streaming}")
+    lines.append(f"workload.concurrency: {cfg.workload.concurrency}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="vllmbench", add_help=True)
+    parser.add_argument(
+        "-f",
+        "--file",
+        dest="files",
+        action="append",
+        required=True,
+        help="Scenario YAML file(s); later files override earlier ones",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        cfg = loader.load_and_validate(args.files)
+    except Exception as e:  # noqa: BLE001 keep simple for CLI
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    sys.stdout.write(_format_summary(cfg))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_cli_summary.py
+++ b/tests/unit/test_cli_summary.py
@@ -30,4 +30,3 @@ def test_cli_applies_overlay_and_updates_summary(capsys: pytest.CaptureFixture[s
     out = capsys.readouterr().out
     assert "workload.streaming: False" in out
     assert "workload.concurrency: [8, 32]" in out
-


### PR DESCRIPTION
### 目标
- [x] 提供最小 CLI：从 YAML 加载并输出摘要

### TDD 证明
- [x] 先提交了失败单测 `test_cli_summary.py`
- [x] 再提交实现 `bench_core.cli`

### 变更说明
- 新增 `bench_core.cli.main(argv)`：
  - 参数：可重复 `-f/--file`，后者覆盖前者
  - 输出：关键字段摘要（schema_version、scenario_name、workload.streaming、workload.concurrency）
- 单测：覆盖单文件与 overlay 覆盖场景

### 风险/回滚
- 若异常：`git revert <merge-commit>`