### PR TITLE
feat(orch): orchestrator skeleton (router selection + plan)

### DIFF
--- a/src/bench_core/__init__.py
+++ b/src/bench_core/__init__.py
@@ -1,5 +1,7 @@
 from . import cli  # re-export for `from bench_core import cli`
+from . import orchestrator  # re-export for `from bench_core import orchestrator`
 
 __all__ = [
     "cli",
+    "orchestrator",
 ]

--- a/src/bench_core/orchestrator.py
+++ b/src/bench_core/orchestrator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, TypedDict
+
+
+@dataclass(frozen=True)
+class BaseRouter:
+    name: str
+
+
+@dataclass(frozen=True)
+class MixedRouter(BaseRouter):
+    strategy: str = "single"
+
+
+@dataclass(frozen=True)
+class SeparatedRouter(BaseRouter):
+    strategy: str = "split"
+
+
+def choose_router(cfg) -> BaseRouter:
+    mode = getattr(getattr(cfg, "pd", None), "mode", "mixed")
+    if mode == "separated":
+        return SeparatedRouter(name="separated")
+    return MixedRouter(name="mixed")
+
+
+class PlanDict(TypedDict):
+    mode: str
+    streaming: bool
+    components: List[str]
+
+
+def build_plan(cfg) -> PlanDict:
+    r = choose_router(cfg)
+    plan: PlanDict = {
+        "mode": r.name,
+        "streaming": bool(cfg.workload.streaming),
+        "components": ["router", "loadgen", "metrics"],
+    }
+    return plan

--- a/tests/data/scenario_separated_overlay.yaml
+++ b/tests/data/scenario_separated_overlay.yaml
@@ -1,0 +1,3 @@
+pd:
+  mode: separated
+

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from bench_core import loader, orchestrator
+
+
+def _fixture_path(name: str) -> str:
+    here = Path(__file__).resolve()
+    root = here.parents[2]
+    return str(root / "tests" / "data" / name)
+
+
+def test_choose_router_mixed_by_default():
+    cfg = loader.load_and_validate([_fixture_path("scenario_base.yaml")])
+    r = orchestrator.choose_router(cfg)
+    assert isinstance(r, orchestrator.MixedRouter)
+    assert r.name == "mixed"
+
+
+def test_choose_router_separated_when_configured():
+    base = _fixture_path("scenario_base.yaml")
+    sep = _fixture_path("scenario_separated_overlay.yaml")
+    cfg = loader.load_and_validate([base, sep])
+    r = orchestrator.choose_router(cfg)
+    assert isinstance(r, orchestrator.SeparatedRouter)
+    assert r.name == "separated"
+
+
+def test_build_plan_contains_mode_and_streaming():
+    base = _fixture_path("scenario_base.yaml")
+    overlay = _fixture_path("scenario_overlay.yaml")  # flips streaming = false
+    cfg = loader.load_and_validate([base, overlay])
+    plan = orchestrator.build_plan(cfg)
+    assert plan["mode"] in {"mixed", "separated"}
+    assert plan["streaming"] is False
+    assert "router" in plan["components"]


### PR DESCRIPTION
### 目标
- [x] 提供最小 Orchestrator：根据 `pd.mode` 选择路由器，并生成简要执行计划

### TDD 证明
- [x] 先提交失败单测 `test_orchestrator.py` 与分离模式夹具
- [x] 再提交实现 `bench_core.orchestrator`

### 变更说明
- 新增 `choose_router(cfg)`：返回 `MixedRouter` 或 `SeparatedRouter`
- 新增 `build_plan(cfg)`：返回 `{ mode, streaming, components }` 简要计划
- 单测覆盖：
  - 混合模式默认选择
  - overlay 切换到分离模式
  - 计划包含 mode/streaming/components 基本要素

### 风险/回滚
- 若异常：`git revert <merge-commit>`