### PR TITLE
feat(manifest): manifest reporter + JSON serializer

### DIFF
--- a/src/bench_core/__init__.py
+++ b/src/bench_core/__init__.py
@@ -1,7 +1,10 @@
 from . import cli  # re-export for `from bench_core import cli`
-from . import orchestrator  # re-export for `from bench_core import orchestrator`
+from . import manifest  # re-export for `from bench_core import manifest`
+from . import \
+    orchestrator  # re-export for `from bench_core import orchestrator`
 
 __all__ = [
     "cli",
     "orchestrator",
+    "manifest",
 ]

--- a/src/bench_core/manifest.py
+++ b/src/bench_core/manifest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def make_manifest(cfg) -> Dict[str, Any]:
+    # Flatten only essential, stable fields for downstream consumers.
+    return {
+        "schema_version": cfg.schema_version,
+        "scenario_name": cfg.scenario_name,
+        "pd_mode": getattr(getattr(cfg, "pd", None), "mode", "mixed"),
+        "workload": {
+            "streaming": bool(cfg.workload.streaming),
+            "input_len": list(cfg.workload.input_len),
+            "output_cap": list(cfg.workload.output_cap),
+            "concurrency": list(cfg.workload.concurrency),
+        },
+        "service": getattr(cfg, "service", None) or {},
+    }
+
+
+def to_json(manifest: Dict[str, Any]) -> str:
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from bench_core import loader, manifest
+
+
+def _fixture_path(name: str) -> str:
+    here = Path(__file__).resolve()
+    root = here.parents[2]
+    return str(root / "tests" / "data" / name)
+
+
+def test_manifest_from_base_config():
+    cfg = loader.load_and_validate([_fixture_path("scenario_base.yaml")])
+    m = manifest.make_manifest(cfg)
+    assert m["schema_version"] == "v1"
+    assert m["scenario_name"] == "basic_stream_toppp"
+    assert m["pd_mode"] == "mixed"
+    assert m["workload"]["streaming"] is True
+    assert m["workload"]["concurrency"] == [4, 16]
+
+
+def test_manifest_respects_overlay_updates():
+    base = _fixture_path("scenario_base.yaml")
+    overlay = _fixture_path("scenario_overlay.yaml")
+    cfg = loader.load_and_validate([base, overlay])
+    m = manifest.make_manifest(cfg)
+    assert m["workload"]["streaming"] is False
+    assert m["workload"]["concurrency"] == [8, 32]
+
+
+def test_manifest_to_json_roundtrip():
+    cfg = loader.load_and_validate([_fixture_path("scenario_base.yaml")])
+    m = manifest.make_manifest(cfg)
+    s = manifest.to_json(m)
+    # ensure it is valid JSON and roundtrips to same dict
+    import json
+
+    assert json.loads(s) == m


### PR DESCRIPTION
### 目标
- [x] 基于场景配置生成稳定的报告清单（manifest），便于产物与契约对齐

### TDD 证明
- [x] 先提交失败单测 `test_manifest.py`
- [x] 再提交实现 `bench_core.manifest`

### 变更说明
- 新增 `make_manifest(cfg)`：输出稳定字段：`schema_version`、`scenario_name`、`pd_mode`、`workload{streaming,input_len,output_cap,concurrency}`、`service`
- 新增 `to_json(manifest)`：稳定 JSON（sorted keys, indent=2, 末尾换行）
- 单测覆盖：基础场景、overlay 覆盖、JSON roundtrip

### 风险/回滚
- 若异常：`git revert <merge-commit>`
